### PR TITLE
Updating the calendar link to work again

### DIFF
--- a/resources/assets/js/components/CurrentDay.vue
+++ b/resources/assets/js/components/CurrentDay.vue
@@ -111,7 +111,7 @@ export default {
                 'trp': 'true',
                 'dates': start + '/' + end
             };
-            window.open('http://www.google.com/calendar/hosted/alliedhealthmedia.com/event?' + $.param(options));
+            window.open('https://calendar.google.com/calendar/u/0/r/eventedit?' + $.param(options));
         },
         sentToCalendar(event) {
             event.pto.is_sent_to_calendar = true;


### PR DESCRIPTION
I'm not certain this is the best way to fix this because this assumes that each user is going to be logged in with their primary account as user 0. I'm opening this up now to start the feedback loop, but want to investigate how I can break that assumption if at all possible.