### PR TITLE
Automatically set the min / max date on the calendar to make choosing PTO easier

### DIFF
--- a/resources/views/pto/_form.blade.php
+++ b/resources/views/pto/_form.blade.php
@@ -41,8 +41,19 @@
 @section('scripts')
 <script>
 $( function() {
-    $(".datepicker").datepicker({
-        'dateFormat': 'yy-mm-dd'
+    $("#start_time").datepicker({
+        dateFormat: 'yy-mm-dd',
+        gotoCurrent: true,
+        onSelect: function(date) {
+            $("#end_time").datepicker("option", "minDate", date);
+        }
+    });
+    $("#end_time").datepicker({
+        dateFormat: 'yy-mm-dd',
+        gotoCurrent: true,
+        onSelect: function(date) {
+            $("#start_time").datepicker("option", "maxDate", date);
+        }
     });
 });
 </script>


### PR DESCRIPTION
When you select a start date, it will automatically move the end date so that it cannot be before the start date to make choosing dates in the future easier.