### PR TITLE
Add missing config/logging.php and Cloud Agent setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,3 +109,58 @@ Test database uses SQLite in-memory.
 - Use Eloquent ORM, avoid raw SQL
 - Keep controllers thin, use traits for shared logic
 - Blade templates with minimal PHP logic
+
+## Cursor Cloud specific instructions
+
+### Docker prerequisite
+
+The development environment runs entirely in Docker. Docker must be installed and running before any `./pto` commands work. On Cloud Agent VMs, Docker requires `fuse-overlayfs` storage driver and `iptables-legacy` (see the Dockerfile-in-Docker setup in the system instructions).
+
+Start the Docker daemon in a tmux session before proceeding:
+
+```bash
+# In a tmux session:
+dockerd &
+```
+
+### First-time setup sequence
+
+```bash
+./pto up                       # Build images & start containers
+./pto composer install         # Install PHP dependencies (dev included)
+./pto artisan key:generate     # Generate APP_KEY (only if .env APP_KEY is empty)
+./pto fresh                    # Migrate & seed database
+./pto build                    # Compile frontend assets (Vue 2 + SCSS)
+```
+
+### `.env` configuration gotchas
+
+- `DB_DATABASE` must be an **absolute path** inside the container: `/var/www/database/database.sqlite` (not the relative `database/database.sqlite` from `docker-setup.sh`).
+- `SESSION_DOMAIN` must be `"localhost"` (without port). Setting it to `"localhost:8000"` breaks cookie/session handling and causes 419 CSRF errors.
+- The project was missing `config/logging.php` (required by Laravel 6's LogManager). A standard single-channel config has been added; without it the app returns 500 on every request.
+
+### Running services
+
+| Service | Container | Port | Notes |
+|---------|-----------|------|-------|
+| PHP-FPM (app) | `pto_tracker_app` | 9000 (internal) | Laravel app server |
+| Nginx (webserver) | `pto_tracker_nginx` | 8000 → 80 | App URL: `http://localhost:8000` |
+| Redis | `pto_tracker_redis` | 6379 | Optional (drivers default to file/sync) |
+| Node | `pto_tracker_node` | — | Asset watcher, auto-starts with `./pto up` |
+
+### Storage permissions
+
+After `./pto up`, fix permissions if you see "Permission denied" errors for `storage/logs`:
+
+```bash
+docker exec pto_tracker_app chmod -R 777 /var/www/storage /var/www/bootstrap/cache
+```
+
+### Test credentials (seeded)
+
+- Admin: `nick.baker@continued.com` / `secret`
+- Regular users are also seeded; check `database/seeds/UserSeeder.php`.
+
+### Known test failure
+
+`Tests\Feature\WorkingWithEmployeesTest::employee_can_remove_their_own_future_pto` fails (pre-existing, not environment-related). 91/92 tests pass.

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,0 +1,49 @@
+<?php
+
+use Monolog\Handler\StreamHandler;
+
+return [
+
+    'default' => env('LOG_CHANNEL', 'single'),
+
+    'channels' => [
+        'stack' => [
+            'driver' => 'stack',
+            'channels' => ['single'],
+            'ignore_exceptions' => false,
+        ],
+
+        'single' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/laravel.log'),
+            'level' => 'debug',
+        ],
+
+        'daily' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/laravel.log'),
+            'level' => 'debug',
+            'days' => 14,
+        ],
+
+        'stderr' => [
+            'driver' => 'monolog',
+            'handler' => StreamHandler::class,
+            'formatter' => env('LOG_STDERR_FORMATTER'),
+            'with' => [
+                'stream' => 'php://stderr',
+            ],
+        ],
+
+        'syslog' => [
+            'driver' => 'syslog',
+            'level' => 'debug',
+        ],
+
+        'errorlog' => [
+            'driver' => 'errorlog',
+            'level' => 'debug',
+        ],
+    ],
+
+];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes the development environment so the app actually runs, and documents the setup for future Cloud Agents.

### Changes

1. **`config/logging.php`** — Added the missing Laravel 6 logging configuration file. The project was upgraded from Laravel 5.x to 6.x but this required config file was never created, causing `Log [] is not defined` errors and 500 responses on every request.

2. **`AGENTS.md`** — Added `## Cursor Cloud specific instructions` section documenting:
   - Docker daemon startup requirement
   - First-time setup sequence
   - `.env` gotchas (absolute SQLite path, `SESSION_DOMAIN` without port)
   - Running services table
   - Storage permission fixes
   - Seeded test credentials
   - Known pre-existing test failure

### Evidence

[pto_tracker_demo.mp4](https://cursor.com/agents/bc-3c18a116-2781-4f97-850f-7c2b124da302/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpto_tracker_demo.mp4)
Demo: registering, logging in, and viewing the PTO calendar dashboard.

[PTO Tracker dashboard showing calendar](https://cursor.com/agents/bc-3c18a116-2781-4f97-850f-7c2b124da302/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpto_dashboard.webp)

### Testing

- **91/92 PHPUnit tests pass** (1 pre-existing failure in `WorkingWithEmployeesTest::employee_can_remove_their_own_future_pto`)
- Frontend assets compile successfully via `./pto build`
- App loads at `http://localhost:8000` with seeded data visible

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c18a116-2781-4f97-850f-7c2b124da302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c18a116-2781-4f97-850f-7c2b124da302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

